### PR TITLE
Agregar script para restablecer por completo el estado de Docker

### DIFF
--- a/docker-reset.sh
+++ b/docker-reset.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+echo "🔧 Deteniendo el servicio Docker..."
+sudo systemctl stop docker
+
+echo "🧨 Borrando todos los datos de Docker..."
+sudo rm -rf /var/lib/docker
+sudo rm -rf /var/lib/containerd
+
+echo "🚀 Reiniciando el servicio Docker..."
+sudo systemctl start docker
+
+echo "✅ Docker ha sido reiniciado. Verificando estado..."
+
+echo -e "\n📦 Contenedores:"
+docker ps -a
+
+echo -e "\n🖼️ Imágenes:"
+docker images -a
+
+echo -e "\n🗃️ Volúmenes:"
+docker volume ls
+
+echo -e "\n🌐 Redes:"
+docker network ls
+
+echo -e "\n✔️ Docker ha sido reseteado completamente."


### PR DESCRIPTION
Se definió el archivo docker-reset.sh, un script que detiene Docker, elimina todos los datos de Docker y de los contenedores, reinicia el servicio y muestra los contenedores, imágenes, volúmenes y redes actuales. Útil para restablecer Docker por completo a un estado limpio en el servidor de producción.