### PR TITLE
Se agregó "nur-network" a Kong service en su docker-compose

### DIFF
--- a/infraestructura/api-gateway/docker-compose.yml
+++ b/infraestructura/api-gateway/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - "8444:8444"   # Admin API con TLS   
       - "8443:8443"   # HTTPS Pública Proxy
     networks:
+      - nur-network
       - kong-net
 
 #  konga:
@@ -83,6 +84,8 @@ services:
 
 networks:
   kong-net:
+    external: true
+  nur-network:
     external: true
 volumes:
   kong-db-data:


### PR DESCRIPTION
El servicio Kong ahora está conectado a la red externa «nur-network», además de a «kong-net». También se define «nur-network» como red externa en el docker-compose de Kong