### PR TITLE
Se actualizó la resolución del host del servicio y el puerto en las configuraciones de Consul

### DIFF
--- a/infraestructura/consul-to-kong/consul-to-kong.php
+++ b/infraestructura/consul-to-kong/consul-to-kong.php
@@ -57,8 +57,8 @@ foreach ($services as $serviceName => $tags) {
     }
 
     $instance = $instances[0];
-    //$host = $instance['ServiceAddress'] ?: $instance['Address'];
-    $host = "host.docker.internal";
+    $host = $instance['ServiceAddress'] ?: $instance['Address'];
+    //$host = "host.docker.internal";
     $port = $instance['ServicePort'];
     $serviceUrl = "http://$host:$port";
 

--- a/infraestructura/consul/config/evaluacion.json
+++ b/infraestructura/consul/config/evaluacion.json
@@ -3,7 +3,7 @@
     "ID": "evaluacion",
     "Name": "evaluacion",
     "Address": "nur-app",
-    "Port": 8081,
+    "Port": 80,
     "Check": {
       "HTTP": "http://nur-app/hola",
       "Interval": "10s",


### PR DESCRIPTION
Se corrigió la resolución dinámica del host en el archivo consul-to-kong.php usando los campos de dirección del servicio en lugar de un valor predefinido. También actualiza el puerto del servicio "evaluacion" de 8081 a 80 en la configuración de Consul ya que en redes Docker internas, los contenedores se comunican entre ellos por el puerto interno y como previamente agregamos a kong a la red de nur-app, se debía hacer esa corrección.